### PR TITLE
Fix GitHub Pages deploy

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,4 +48,4 @@ jobs:
           path: dist                 # <- vite’s default output
 
       - id: deploy
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2H28W12C3V"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-2H28W12C3V');
+    </script>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☕</text></svg>"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Coffee</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,22 @@ import react from '@vitejs/plugin-react-swc'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
+  // When running in GitHub Actions we want the base path to match the
+  // repository name so that GitHub Pages works correctly. This grabs the repo
+  // from GITHUB_REPOSITORY (`owner/repo`) and uses `/repo/` as the base. For
+  // local development we keep the existing `/absproxy/5173` path.
+  const repo = process.env.GITHUB_REPOSITORY?.split('/')[1]
+  const basePath =
+    mode === 'development'
+      ? '/absproxy/5173'
+      : process.env.GITHUB_ACTIONS && repo
+        ? `/${repo}/`
+        : '/'
+
   return {
     plugins: [react()],
     // a bunch of stuff to get code server working
-    base: mode === 'development' ? "/absproxy/5173" : "/",
+    base: basePath,
     server: mode === 'development' ? {
       allowedHosts: [
         "bios-kubuntu.home.arpa",


### PR DESCRIPTION
## Summary
- auto-detect repo for `vite` base path so GitHub Pages gets the right root
- ship a `public/404.html` for SPA routing
- use latest `deploy-pages` action

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*