### PR TITLE
Disable post-move vote restrictions

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -493,7 +493,10 @@ export default function Board(props) {
   // Loop through each card that has votes
   // If any voted card is past first column, voting is disabled.
   // const votingDisabled = Object.keys(voteTotals).some( cardId => cards.some( card => ) )
-  const votingDisabled = cards.some( card => card.col != 0 && voteTotals.calculated[card.id])
+  // Voting was previously disabled once any vote was present in a non-To-Do column.
+  // This logic has been turned off by forcing votingDisabled to false.
+  // const votingDisabled = cards.some( card => card.col != 0 && voteTotals.calculated[card.id])
+  const votingDisabled = false
   //   console.log(card, card.col, card.col != 0, card.id, voteTotals, voteTotals.calculated[card.id])
 
   // } )

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -496,7 +496,9 @@ export default function Board(props) {
   // Voting was previously disabled once any vote was present in a non-To-Do column.
   // This logic has been turned off by forcing votingDisabled to false.
   // const votingDisabled = cards.some( card => card.col != 0 && voteTotals.calculated[card.id])
+  // const votingDisabled = false
   const votingDisabled = false
+  
   //   console.log(card, card.col, card.col != 0, card.id, voteTotals, voteTotals.calculated[card.id])
 
   // } )
@@ -692,7 +694,7 @@ export default function Board(props) {
                                 voteTotals.mine[card.id]
                               ) || 0}
                             </span>
-                            <button disabled={votingDisabled} className="disabled:opacity-25" onClick={() => voteAdd(card.id, voteTotals.mine[card.id])}><FontAwesomeIcon icon={faPlus} /></button>
+                            <button disabled={voteTotals.mineTotal >= 8} className="disabled:opacity-25" onClick={() => voteAdd(card.id, voteTotals.mine[card.id])}><FontAwesomeIcon icon={faPlus} /></button>
                           </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- disable the logic that prevented voting once a card with votes was moved out of the first column

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing script)*