### PR TITLE
Fix TODO storing sort order

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -97,7 +97,13 @@ export default function Board(props) {
   const [votes, setVotes] = useState()
   const columns = ['Topics', 'Discussing', 'Done'] // type: lean
 
-  const [voteSort, setVoteSort] = useState('created') // TODO: localStorage
+  const [voteSort, setVoteSort] = useState(
+    () => localStorage.getItem('voteSort') || 'created'
+  )
+
+  useEffect(() => {
+    localStorage.setItem('voteSort', voteSort)
+  }, [voteSort])
 
   useEffect( () => {
 


### PR DESCRIPTION
## Summary
- persist vote sort order in localStorage

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*