### PR TITLE
Add share target

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Store } from "../hooks/useStore";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { supabase } from "../hooks/useSupabase";
@@ -332,6 +332,16 @@ export default function Board(props) {
 
   const [editing, setEditing] = useState([])
   const [cardNewForm, setCardNewForm] = useState([])
+  const [searchParams] = useSearchParams()
+  const shareParam = searchParams.get('share')
+  const shareData = shareParam ? JSON.parse(decodeURIComponent(shareParam)) : null
+  const [shareText] = useState(shareData ? JSON.stringify(shareData, null, 2) : '')
+
+  useEffect(() => {
+    if(shareData && !cardNewForm.includes(0)) {
+      setCardNewForm([0])
+    }
+  }, [shareData])
 
   // Toggle by either adding the id if not there, or returning the array without it if present
   const cardEditToggle = (id) => {
@@ -656,7 +666,7 @@ export default function Board(props) {
                         {cardNewForm.includes(colIndex) ? (
                           <form onSubmit={cardNewSubmit} className="flex flex-col gap-y-2">
                             <input type="hidden" name="col" value={colIndex} />
-                            <textarea autoFocus className="border rounded w-full px-2 py-1" name="text" placeholder="New Card" rows={5} />
+                            <textarea autoFocus className="border rounded w-full px-2 py-1" name="text" placeholder="New Card" rows={5} defaultValue={shareText} />
                             <button name="addCardBtn" className="text-center bg-green-500 p-2 text-white font-medium disabled:opacity-25">
                               <FontAwesomeIcon icon={faNoteSticky} /> Add Card
                             </button>

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -51,6 +51,8 @@ export default function Board(props) {
   const navigate = useNavigate()
   const { board_id } = useParams()
 
+  localStorage.setItem("lastBoard", board_id);
+
   const { psuedonym, boards } = useContext(Store)
   // const psuedonym.psuedonym = psuedonym.psuedonym // TODO: clean this up
 

--- a/src/components/ShareTarget.jsx
+++ b/src/components/ShareTarget.jsx
@@ -1,0 +1,29 @@
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useContext, useEffect } from 'react';
+import { Store } from '../hooks/useStore';
+
+export default function ShareTarget() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const store = useContext(Store);
+
+  useEffect(() => {
+    if(!store?.boards) return;
+    const data = {
+      title: searchParams.get('title'),
+      text: searchParams.get('text'),
+      url: searchParams.get('url')
+    };
+    const payload = encodeURIComponent(JSON.stringify(data));
+    const boardId = store.boards[0]?.id;
+    if(boardId) {
+      navigate(`/board/${boardId}?share=${payload}`);
+    } else {
+      navigate('/');
+    }
+  }, [store, searchParams, navigate]);
+
+  return (
+    <div className="text-center pt-32">Loading...</div>
+  );
+}

--- a/src/components/ShareTarget.jsx
+++ b/src/components/ShareTarget.jsx
@@ -15,7 +15,7 @@ export default function ShareTarget() {
       url: searchParams.get('url')
     };
     const payload = encodeURIComponent(JSON.stringify(data));
-    const boardId = store.boards[0]?.id;
+    const boardId = localStorage.getItem("lastBoard") ?? store.boards[0]?.id;
     if(boardId) {
       navigate(`/board/${boardId}?share=${payload}`);
     } else {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ import App from './App.jsx'
 import Home from './components/Home.jsx';
 import Board from './components/Board.jsx';
 import Test from './components/Test';
+import ShareTarget from './components/ShareTarget.jsx';
 
 const router = createRouter([
   // {
@@ -33,6 +34,10 @@ const router = createRouter([
       {
         path: "/board/:board_id",
         element: <Board />
+      },
+      {
+        path: "/share-target",
+        element: <ShareTarget />
       }
     ]
   },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,8 +11,14 @@ import {
 import App from './App.jsx'
 import Home from './components/Home.jsx';
 import Board from './components/Board.jsx';
-import Test from './components/Test';
 import ShareTarget from './components/ShareTarget.jsx';
+
+// https://github.com/vuejs/vue-router/issues/2125#issuecomment-519521424
+if (window.location.search) {
+  window.location.replace(
+    window.location.pathname + window.location.hash + window.location.search
+  );
+}
 
 const router = createRouter([
   // {

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,6 +22,15 @@ export default defineConfig(({ mode }) => {
           name: 'Coffee',
           short_name: 'Coffee',
           description: 'The cleanest lean coffee solution',
+          share_target: {
+            action: '/share-target',
+            method: 'GET',
+            params: {
+              title: 'title',
+              text: 'text',
+              url: 'url'
+            }
+          },
           display: 'standalone',
           background_color: '#ffffff',
           theme_color: '#ffffff',


### PR DESCRIPTION
## Summary
- allow sharing directly into the PWA
- handle a `/share-target` route that redirects to the first board
- pre-fill new card form with shared data

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*