### PR TITLE
Improve share target formatting and reset

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -237,11 +237,15 @@ export default function Board(props) {
     const { error } = await supabase
       .from('cards')
       .insert(insert)
-    
+
     // Reset input form
     event.target.reset()
     event.target.text.disabled = false
     event.target.addCardBtn.disabled = false
+
+    // Clear share info so subsequent cards are blank
+    setShareText('')
+    setSearchParams({})
 
     // Re-focus textarea
     event.target.text.focus()
@@ -334,16 +338,18 @@ export default function Board(props) {
 
   const [editing, setEditing] = useState([])
   const [cardNewForm, setCardNewForm] = useState([])
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const shareParam = searchParams.get('share')
-  const shareData = shareParam ? JSON.parse(decodeURIComponent(shareParam)) : null
-  const [shareText] = useState(shareData ? JSON.stringify(shareData, null, 2) : '')
+  const [shareText, setShareText] = useState(
+    shareParam ? decodeURIComponent(shareParam) : ''
+  )
 
   useEffect(() => {
-    if(shareData && !cardNewForm.includes(0)) {
+    if(shareParam && !cardNewForm.includes(0)) {
       setCardNewForm([0])
     }
-  }, [shareData])
+    setShareText(shareParam ? decodeURIComponent(shareParam) : '')
+  }, [shareParam])
 
   // Toggle by either adding the id if not there, or returning the array without it if present
   const cardEditToggle = (id) => {

--- a/src/components/ShareTarget.jsx
+++ b/src/components/ShareTarget.jsx
@@ -9,12 +9,16 @@ export default function ShareTarget() {
 
   useEffect(() => {
     if(!store?.boards) return;
-    const data = {
-      title: searchParams.get('title'),
-      text: searchParams.get('text'),
-      url: searchParams.get('url')
-    };
-    const payload = encodeURIComponent(JSON.stringify(data));
+    const fields = [
+      ['Title', searchParams.get('title')],
+      ['Text', searchParams.get('text')],
+      ['URL', searchParams.get('url')]
+    ];
+    const cardContent = fields
+      .filter(([, value]) => value)
+      .map(([label, value]) => `> ${label}: ${value}`)
+      .join('\n');
+    const payload = encodeURIComponent(cardContent);
     const boardId = localStorage.getItem("lastBoard") ?? store.boards[0]?.id;
     if(boardId) {
       navigate(`/board/${boardId}?share=${payload}`);


### PR DESCRIPTION
## Summary
- clean up ShareTarget by formatting shared data in block quotes instead of JSON
- reset share info after creating a card

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*